### PR TITLE
Fixed STEAMUSER_HOME in util/steambox launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Builds a [SteamOS](http://store.steampowered.com/steamos/) [docker](https://www.
 > ```
 export STEAMUSER_UID=$(id -u ${USER})
 export STEAMUSER_GID=$(id -g ${USER})
-export STEAMUSER_HOME=~${USER}
+export STEAMUSER_HOME=${HOME}
 mkdir -p ~${USER}/steamhome && chown ${USER}:${USER} ${USER}/steamhome
 make
 util/steambox

--- a/util/steambox
+++ b/util/steambox
@@ -37,7 +37,7 @@ STEAMBOX=${STEAMBOX:-"steambox"}
 STEAMUSER_DISPLAY=${STEAMUSER_DISPLAY:-":0"}
 
 echo STEAMUSER_UID=${STEAMUSER_UID:?"$0: you must set the environment variable STEAMUSER_UID"}
-echo STEAMUSER_HOME=${STEAMUSER_UID:?"$0: you must set the environment variable STEAMUSER_HOME"}
+echo STEAMUSER_HOME=${STEAMUSER_HOME:?"$0: you must set the environment variable STEAMUSER_HOME"}
 echo STEAMUSER_DISPLAY=${STEAMUSER_DISPLAY}
 
 STEAMHOME="${STEAMUSER_HOME}/steamhome"
@@ -65,7 +65,7 @@ declare -a PULSE_ARGS=(
 	-v /etc/machine-id:/etc/machine-id:ro
 	-v "/run/user/${STEAMUSER_UID}/pulse:/run/user/${STEAMUSER_UID}/pulse"
 	-v /var/lib/dbus:/var/lib/dbus
-	-v "${STEAMUSER_HOME}/.pulse:${STEAMHOME}/.pulse"
+	-v "${STEAMUSER_HOME}/.pulse:/home/steamuser/.pulse"
 )
 
 echo $0: Using args: "${HOMEDIR_ARGS[@]}" "${X11_ARGS[@]}" "${ALSA_ARGS[@]}" "${PULSE_ARGS[@]}"


### PR DESCRIPTION
My Debian Jessie (8.7) with upstream 1.13.0-0 docker-engine package will not start a container with a volume specified with `~user' syntax - it requires a full path.
